### PR TITLE
Fix perl warnings in the neutrinet script

### DIFF
--- a/neutrinet.sh
+++ b/neutrinet.sh
@@ -123,6 +123,7 @@ modify_hosts() {
 
 set_locales() {
     [ "$(grep LC_ALL /etc/environment)" ] || echo 'LC_ALL="fr_FR.UTF-8"' >> /etc/environment
+    source /etc/environment
 }
 
 upgrade_system() {


### PR DESCRIPTION
During the execution of the neutrinet.sh script, Perl is complaining a
dozen times about the locale. The LC_ALL env variable is correctly set
in the /etc/environment, but it is not sourced, so the env variable
won't be taken into account for the current session.

Example of the perl error message:
```
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
 LANGUAGE = (unset),
 LC_ALL = (unset),
 LC_TIME = "fr_BE.UTF-8",
 LC_MONETARY = "fr_BE.UTF-8",
 LC_ADDRESS = "fr_BE.UTF-8",
 LC_TELEPHONE = "fr_BE.UTF-8",
 LC_NAME = "fr_BE.UTF-8",
 LC_MEASUREMENT = "fr_BE.UTF-8",
 LC_IDENTIFICATION = "fr_BE.UTF-8",
 LC_NUMERIC = "fr_BE.UTF-8",
 LC_PAPER = "fr_BE.UTF-8",
 LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to a fallback locale ("en_US.UTF-8").
```

You can see it in action by just running: `perl -e exit` with the `LC_ALL` env variable not set.