### PR TITLE
Fix perl warnings in the neutrinet script (part 2)

### DIFF
--- a/neutrinet.sh
+++ b/neutrinet.sh
@@ -122,8 +122,9 @@ modify_hosts() {
 }
 
 set_locales() {
-    [ "$(grep LC_ALL /etc/environment)" ] || echo 'LC_ALL="fr_FR.UTF-8"' >> /etc/environment
+    [ "$(grep LC_ALL /etc/environment)" ] || echo 'LC_ALL="en_US.UTF-8"' >> /etc/environment
     source /etc/environment
+    export LC_ALL
 }
 
 upgrade_system() {


### PR DESCRIPTION
It is not enough to source `/etc/environment`.
Sourcing the file set the `LC_ALL` variable, but it doesn’t export it.

This commit also switch the locale from French to English.